### PR TITLE
eu4: use cp1252 encoding for definition.csv

### DIFF
--- a/pyradox/worldmap.py
+++ b/pyradox/worldmap.py
@@ -63,7 +63,12 @@ class ProvinceMap():
         if flip_y:
             self.province_image = self.province_image.transpose(Image.FLIP_TOP_BOTTOM)
 
-        with open(definition_csv) as definition_file:
+        if game == 'EU4':
+            encoding = 'cp1252'
+        else:
+            encoding = None
+
+        with open(definition_csv, encoding=encoding) as definition_file:
             csv_reader = csv.reader(definition_file, delimiter = ';')
             self.province_color_by_id = {}
             self.province_id_by_color = {}


### PR DESCRIPTION
Hi,
are you still working on pyradox? I made some changes to a few eu4 scripts so they work again and created a script to generate the monument map for the eu4 wiki. I'm currently in the process of publishing the changes to my pyradox fork. Are you interested in more pull requests?
This pull request is to make eu4 map scripts work on systems which use utf8 as default encoding (presumably all Linux systems), because they can't read definition.csv and throw a UnicodeDecodeError.
I decided to start with this change, because it is needed for all map scripts, but my solution is not really good. I just made a special case for eu4 in the ProvinceMap class. I don't own any of the hoi games(and neither ck3), so I can't check which encoding they use for the definition.csv. If all use cp1252, a special case would be unnecessary. And a better solution would probably be to specific the encodings for each game in a central place (txt.py already has something like this).

grotaclas