### PR TITLE
Remove BOM characters from file and string parsing

### DIFF
--- a/src/pyradox/filetype/txt.py
+++ b/src/pyradox/filetype/txt.py
@@ -21,6 +21,8 @@ def readlines(filename, encodings):
         try:
             with open(filename, encoding=encoding) as f:
                 lines = f.readlines()
+            if lines and lines[0] and lines[0][0] == '\ufeff':
+                lines[0] = lines[0][1:]
             return lines
         except UnicodeDecodeError:
             warnings.warn(ParseWarning("Failed to decode input file %s using codec %s." % (filename, encoding)))
@@ -28,6 +30,8 @@ def readlines(filename, encodings):
 
 def parse(s, filename="<string>"):
     """Parse a string."""
+    if s and s[0] == '\ufeff':
+        s = s[1:]
     lines = s.splitlines()
     token_data = lex(lines, filename)
     return parse_tree(token_data, filename)


### PR DESCRIPTION
## Summary
This change adds handling for UTF-8 Byte Order Mark (BOM) characters that may appear at the beginning of input files and strings. The BOM character (`\ufeff`) is now stripped during parsing to prevent it from being treated as part of the actual content.

## Key Changes
- **File parsing (`readlines`)**: Added check to detect and remove BOM from the first line when reading files
- **String parsing (`parse`)**: Added check to detect and remove BOM from the beginning of input strings before tokenization

## Implementation Details
- The BOM character (`\ufeff`) is checked at the start of both file content and string input
- Removal is only performed if content exists and starts with the BOM character
- This ensures compatibility with files saved with UTF-8 BOM encoding, which is common in some editors and Windows environments
- The fix is applied early in the parsing pipeline to prevent the BOM from propagating to the lexer and parser

https://claude.ai/code/session_01M967DCwxUY2afjZEAkmD1s